### PR TITLE
Add support for opencv-4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-CFLAGS=`pkg-config --cflags opencv`
-LDFLAGS=`pkg-config --libs-only-L opencv` -lopencv_core -lopencv_highgui -lopencv_imgcodecs -lopencv_imgproc
+CFLAGS=`pkg-config --cflags --libs opencv4`
+LDFLAGS=`pkg-config --libs-only-L opencv4` -lopencv_core -lopencv_highgui -lopencv_imgcodecs -lopencv_imgproc
 ssimulacra: ssimulacra.cpp
 	g++ -std=c++11 -O2 -fstrict-aliasing -ffast-math $(CFLAGS) ssimulacra.cpp $(LDFLAGS) -o ssimulacra
 clean:


### PR DESCRIPTION
The current version of opencv is 4 and you get this build error with the current makefile:

```
g++ -std=c++11 -O2 -fstrict-aliasing -ffast-math `pkg-config --cflags opencv` ssimulacra.cpp `pkg-config --libs-only-L opencv` -lopencv_core -lopencv_highgui -lopencv_imgcodecs -lopencv_imgproc -o ssimulacra
Package opencv was not found in the pkg-config search path.
Perhaps you should add the directory containing `opencv.pc'
to the PKG_CONFIG_PATH environment variable
No package 'opencv' found
Package opencv was not found in the pkg-config search path.
Perhaps you should add the directory containing `opencv.pc'
to the PKG_CONFIG_PATH environment variable
No package 'opencv' found
ssimulacra.cpp:81:10: fatal error: opencv2/opencv.hpp: No such file or directory
   81 | #include <opencv2/opencv.hpp>
      |          ^~~~~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:4: ssimulacra] Error 1
```

This PR makes compilation succeed with opencv4.

Credits:
- https://stackoverflow.com/a/58290585
- https://github.com/haeky/ssimulacra who also seems to have done the same thing independently @haeky
 